### PR TITLE
redirect with 303 so as not to carry :DELETE method

### DIFF
--- a/lib/like/interaction.rb
+++ b/lib/like/interaction.rb
@@ -12,7 +12,7 @@ class Like::Interaction
   end
 
   def post_action
-    controller.redirect_to :back
+    controller.redirect_to :back, status: 303
   end
 
   def pre_action


### PR DESCRIPTION
The 302 redirect causes the HTML method to be preserved and carried across.  So when redirecting from the index, when unliking it will push the user back to the **destroy** action.

Added 303 to redirect to prevent the method sticking.

I know all of this is customisable, it's just not the best default behaviour.  Results in deleting objects when unliking.
